### PR TITLE
Fix numpy installation and small README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,19 @@ Siamese Mask R-CNN extends Mask R-CNN (a state-of-the-art object detection and s
 
 2. Install dependencies
 ```bash
+cd Small_data_visual_search_app
 conda env create -f environment.yml
+conda activate updated-app
 ```
 
 3. Create folders
 ```bash
-cd Small_data_visual_search_app
-mkdir checkpoints -p data/coco 
+mkdir -p checkpoints data/coco 
 ```
 
 4. Download pretrained weights from the [releases menu](https://github.com/EzheZhezhe/Small_data_visual_search_app/releases) and place them in `checkpoints` folder
 
-5. Prepare [MSCOCO Dataset]((http://cocodataset.org/download))
+5. Prepare [MSCOCO Dataset]((http://cocodataset.org/#download))
 
 Inference part requires the CocoAPI and MS COCO Val2017 and Test2017 images, Train/Val2017 annotations to be added to `/data/coco` folder.
 
@@ -58,8 +59,9 @@ Inference part requires the CocoAPI and MS COCO Val2017 and Test2017 images, Tra
 ```
 cd data/coco
 git clone https://github.com/waleedka/coco
-cd PythonAPI
-sudo make install
+cd coco/PythonAPI
+make install
+cd ../../../..
 ```
 * Second, return to the workshop root folder and run python script to upload 2017 Val and Test dataset and Train/Val annotaions. At least 8GB free space on disc required.
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -16,5 +16,5 @@ dependencies:
     - python-multipart 
     - scikit_image==0.13.1
     - uvicorn
- 
+    - numpy==1.14.1
 


### PR DESCRIPTION
With the current master version, at least on my Mac, pip will upgrade numpy to version 1.18.5, which is incompatible with the included version of scikit-image. This PR prevents pip from upgrading numpy.

This also fixes a few minor things in README.md:
* There were a couple of `cd`s in the wrong place.
* There was a broken link in the README.
* On Mac, `mkdir foo -p bar/baz` will create directories `foo` and `-p`, and will complain about `bar` not existing. So I changed the mkdir command to work on both Mac and Linux.
* When running inside a conda environment, make install does not have to be (and should not be) run as root, because it will install within the conda environment, which should be owned by the user.
